### PR TITLE
Linux and Windows compatible identification of main script file name

### DIFF
--- a/pemfc_gui/entry_value.py
+++ b/pemfc_gui/entry_value.py
@@ -1,11 +1,7 @@
 import os
-import __main__ as main
 import sys
 
 main_name=sys.argv[0]
-
-
-
 
 if 'gui_app.py' in main_name:
     from tkinter.messagebox import showerror
@@ -38,7 +34,6 @@ class EntryValue:
 
     def __set__(self, instance, value):
         self._value = value
-
 
 
 if 'gui_app.py' in main_name:

--- a/pemfc_gui/entry_value.py
+++ b/pemfc_gui/entry_value.py
@@ -1,8 +1,7 @@
 import os
 import sys
 
-main_name=sys.argv[0]
-
+main_name = sys.argv[0]
 if 'gui_app.py' in main_name:
     from tkinter.messagebox import showerror
 

--- a/pemfc_gui/entry_value.py
+++ b/pemfc_gui/entry_value.py
@@ -1,7 +1,13 @@
 import os
 import __main__ as main
-main_name = os.path.basename(main.__file__)
-if main_name == 'gui_app.py':
+import sys
+
+main_name=sys.argv[0]
+
+
+
+
+if 'gui_app.py' in main_name:
     from tkinter.messagebox import showerror
 
 
@@ -34,7 +40,8 @@ class EntryValue:
         self._value = value
 
 
-if main_name == 'gui_app.py':
+
+if 'gui_app.py' in main_name:
 
     class EntryValueFactory:
         def create(self, value, dtype, widget_set):


### PR DESCRIPTION
os.path.basename(main.__ file __) seems not to work at Linux or et least not at Ubuntu 20.04:
![image](https://user-images.githubusercontent.com/94350939/150523776-0d2505c6-e736-4df8-8308-381fa5431ad5.png)

I found out that...

1. __ main __ has not always a __ file __ attribute. [https://stackoverflow.com/questions/606561/how-to-get-filename-of-the-main-module-in-python] 
2. output of __ file __ recently changed:
"From Python3.9 onwards, per issue 20443, the __file__ attribute of the __main__ module became an absolute path, rather than a relative path." [https://stackoverflow.com/questions/4152963/get-name-of-current-script-in-python]

Solution based on:
https://stackoverflow.com/questions/4152963/get-name-of-current-script-in-python

Check for substring
`if 'main_app.py' in main_name:`
 is requied due to different return of sys.argv[0] in Linux and Windows.


